### PR TITLE
No need to depend on a publish-local'd chisel.

### DIFF
--- a/ChiselProject/sbt/build.sbt
+++ b/ChiselProject/sbt/build.sbt
@@ -1,10 +1,16 @@
 scalaVersion in ThisBuild := "2.11.7"
 
+val chiselVersion = "88293703119ed6468235bf240b16c637999add61"
+
+lazy val chisel = ProjectRef(
+  uri("git://github.com/ucb-bar/chisel.git#%s".format(chiselVersion)),
+  "chisel"
+)
+
 val prjSettings = Project.defaultSettings ++ Seq(
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:reflectiveCalls",
                         "-language:implicitConversions", "-language:existentials"),
   libraryDependencies += "org.json4s" %% "json4s-native" % "3.3.0",
-  libraryDependencies += "edu.berkeley.cs" %% "chisel" % "2.3-SNAPSHOT",
   libraryDependencies  ++= Seq(
     "org.scalanlp" %% "breeze" % "0.12",
     "org.scalanlp" %% "breeze-natives" % "0.12",
@@ -12,12 +18,12 @@ val prjSettings = Project.defaultSettings ++ Seq(
   ),
   libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-compiler" % _ ) 
 )
- 
+
 lazy val ChiselCompatibility = Project(
   id = "chisel-compatibility", 
   base = file("ChiselCompatibility"),
   settings = prjSettings
-)
+).dependsOn(chisel)
 
 lazy val ChiselDSP_Overlay = Project(
   id = "chisel-dsp-overlay",


### PR DESCRIPTION
We recently upstreamed optionable bundles to main chisel. Until there is a new release, we have been using the publish-local'd chisel. This is annoying and makes it hard to keep track of what version of chisel you are using.

There is a better way!

Chisel is added as a subproject with a git uri. This more or less does the same thing, except that it allows you to use a specific version of chisel without polluting the ivy cache. Also, nobody needs to remember how to publish-local chisel.
